### PR TITLE
Remove tabs, line feeds, carriage returns from the wkt before using it to display the geometry on the map.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -82,38 +82,38 @@ function App() {
             draw={{
               rectangle: {
                 shapeOptions: {
-                    opacity: 1,
-                    fillOpacity: 0.2,
-                    weight: 3,
-                    color: "#3388ff",
-                    fill: "#3388ff"
+                  opacity: 1,
+                  fillOpacity: 0.2,
+                  weight: 3,
+                  color: "#3388ff",
+                  fill: "#3388ff"
                 }
               },
               marker: false,
               circle: false,
               polygon: {
                 shapeOptions: {
-                    opacity: 1,
-                    fillOpacity: 0.2,
-                    weight: 3,
-                    color: "#3388ff",
-                    fill: "#3388ff"
-                }
-              },
-              circlemarker: {
                   opacity: 1,
                   fillOpacity: 0.2,
                   weight: 3,
-                  radius: 4,
                   color: "#3388ff",
                   fill: "#3388ff"
+                }
+              },
+              circlemarker: {
+                opacity: 1,
+                fillOpacity: 0.2,
+                weight: 3,
+                radius: 4,
+                color: "#3388ff",
+                fill: "#3388ff"
               },
               polyline: {
                 shapeOptions: {
-                    opacity: 1,
-                    weight: 3,
-                    color: "#3388ff",
-                    fill: false
+                  opacity: 1,
+                  weight: 3,
+                  color: "#3388ff",
+                  fill: false
                 }
               }
             }}
@@ -147,9 +147,9 @@ function App() {
       fetchWkt(hash);
     }
   }, [map]); // eslint-disable-line react-hooks/exhaustive-deps
-  
+
   function splitGeometry(geometry) {
-    if (geometry.type === "GeometryCollection") { 
+    if (geometry.type === "GeometryCollection") {
       return geometry.geometries;
     } else {
       return [geometry];
@@ -214,11 +214,17 @@ function App() {
     });
   }
 
+  function trimWkt(wkt)
+  {
+    return wkt.replace(/\s+/g, ' ').trim();
+  }
+
   function handleWktChange(e) {
     clearHash();
-    setWkt(e.target.value);
+    const wkt = trimWkt(e.target.value)
+    setWkt(wkt);
     processInput({
-      wkt: e.target.value,
+      wkt: wkt,
       epsg: epsg
     });
   }
@@ -245,7 +251,7 @@ function App() {
       headers: {
         "Content-Type": "application/json"
       }
-    }).catch(error => console.error(error)); 
+    }).catch(error => console.error(error));
     window.history.replaceState(null, null, "?" + hash);
     setShowUrl(true);
     ReactGA.event({
@@ -314,7 +320,7 @@ function App() {
     <div id="app">
 
       <ToastContainer className="p-3" position="top-end">
-      <Toast onClose={() => setShowUrl(false)} show={showUrl} delay={5000} autohide className="">
+        <Toast onClose={() => setShowUrl(false)} show={showUrl} delay={5000} autohide className="">
           <Toast.Body>Generated URL for sharing</Toast.Body>
         </Toast>
         <Toast onClose={() => setShowCopied(false)} show={showCopied} delay={5000} autohide className="">

--- a/src/App.js
+++ b/src/App.js
@@ -214,11 +214,17 @@ function App() {
     });
   }
 
+  function trimWkt(wkt)
+  {
+    return wkt.replace(/\s+/g, ' ').trim();
+  }
+
   function handleWktChange(e) {
     clearHash();
-    setWkt(e.target.value);
+    const wkt = trimWkt(e.target.value)
+    setWkt(wkt);
     processInput({
-      wkt: e.target.value,
+      wkt: wkt,
       epsg: epsg
     });
   }

--- a/src/App.js
+++ b/src/App.js
@@ -82,38 +82,38 @@ function App() {
             draw={{
               rectangle: {
                 shapeOptions: {
-                  opacity: 1,
-                  fillOpacity: 0.2,
-                  weight: 3,
-                  color: "#3388ff",
-                  fill: "#3388ff"
+                    opacity: 1,
+                    fillOpacity: 0.2,
+                    weight: 3,
+                    color: "#3388ff",
+                    fill: "#3388ff"
                 }
               },
               marker: false,
               circle: false,
               polygon: {
                 shapeOptions: {
-                  opacity: 1,
-                  fillOpacity: 0.2,
-                  weight: 3,
-                  color: "#3388ff",
-                  fill: "#3388ff"
+                    opacity: 1,
+                    fillOpacity: 0.2,
+                    weight: 3,
+                    color: "#3388ff",
+                    fill: "#3388ff"
                 }
               },
               circlemarker: {
-                opacity: 1,
-                fillOpacity: 0.2,
-                weight: 3,
-                radius: 4,
-                color: "#3388ff",
-                fill: "#3388ff"
+                  opacity: 1,
+                  fillOpacity: 0.2,
+                  weight: 3,
+                  radius: 4,
+                  color: "#3388ff",
+                  fill: "#3388ff"
               },
               polyline: {
                 shapeOptions: {
-                  opacity: 1,
-                  weight: 3,
-                  color: "#3388ff",
-                  fill: false
+                    opacity: 1,
+                    weight: 3,
+                    color: "#3388ff",
+                    fill: false
                 }
               }
             }}
@@ -147,9 +147,9 @@ function App() {
       fetchWkt(hash);
     }
   }, [map]); // eslint-disable-line react-hooks/exhaustive-deps
-
+  
   function splitGeometry(geometry) {
-    if (geometry.type === "GeometryCollection") {
+    if (geometry.type === "GeometryCollection") { 
       return geometry.geometries;
     } else {
       return [geometry];
@@ -214,17 +214,11 @@ function App() {
     });
   }
 
-  function trimWkt(wkt)
-  {
-    return wkt.replace(/\s+/g, ' ').trim();
-  }
-
   function handleWktChange(e) {
     clearHash();
-    const wkt = trimWkt(e.target.value)
-    setWkt(wkt);
+    setWkt(e.target.value);
     processInput({
-      wkt: wkt,
+      wkt: e.target.value,
       epsg: epsg
     });
   }
@@ -251,7 +245,7 @@ function App() {
       headers: {
         "Content-Type": "application/json"
       }
-    }).catch(error => console.error(error));
+    }).catch(error => console.error(error)); 
     window.history.replaceState(null, null, "?" + hash);
     setShowUrl(true);
     ReactGA.event({
@@ -320,7 +314,7 @@ function App() {
     <div id="app">
 
       <ToastContainer className="p-3" position="top-end">
-        <Toast onClose={() => setShowUrl(false)} show={showUrl} delay={5000} autohide className="">
+      <Toast onClose={() => setShowUrl(false)} show={showUrl} delay={5000} autohide className="">
           <Toast.Body>Generated URL for sharing</Toast.Body>
         </Toast>
         <Toast onClose={() => setShowCopied(false)} show={showCopied} delay={5000} autohide className="">


### PR DESCRIPTION
Replace any white space character like (spaces, tabs, and newlines) with a white space character. 
Copying wkt from a pdf sometimes creates newlines to be inserted inside the WKT. Pasting it into wktmap.com is gives issues, hence this small fix.

Example wkt that gave issues: POLYGON ((4.039569 50.938106, 4.039495 50.938106, 4.039471 50.938106, 4.039488 50.93791, 4.039488 50.937908, 4.03954
50.937913, 4.039591 50.937911, 4.039588 50.937978, 4.039575 50.937977, 4.039569 50.938106))